### PR TITLE
fix: Virus definition update failing due to lambda tmp storage limit

### DIFF
--- a/API.md
+++ b/API.md
@@ -23,7 +23,7 @@ An [aws-cdk](https://github.com/aws/aws-cdk) construct that uses [ClamAV®](http
 The construct creates a Lambda function with EFS integration to support larger files.
 A VPC with isolated subnets, a S3 Gateway endpoint will also be created.
 
-Additionally creates an hourly job to download the latest ClamAV definition files to the
+Additionally creates an twice-daily job to download the latest ClamAV definition files to the
 Virus Definitions S3 Bucket by utilizing an EventBridge rule and a Lambda function and
 publishes CloudWatch Metrics to the 'serverless-clamscan' namespace.
 

--- a/assets/lambda/code/download_defs/lambda.py
+++ b/assets/lambda/code/download_defs/lambda.py
@@ -43,7 +43,10 @@ def download_s3_defs(download_path, defs_bucket):
     """download CVD and conf files from definitions bucket (if they exist)
     to compare against ClamAV database. Respect their hosting costs!"""
     try:
-        file_regex = [r"\w+.c[vl]d", r"freshclam.conf"]
+        # Downloading ClamAV definitions and exceeds Lambda's tmp directory max size
+        # https://github.com/awslabs/cdk-serverless-clamscan/issues/118
+        # file_regex = [r"\w+.c[vl]d", r"freshclam.conf"]
+        file_regex = [r"freshclam.conf"]
         file_pattern = r"||".join(file_regex)
         for file in defs_bucket.objects.all():
             filename = file.key
@@ -78,6 +81,7 @@ def freshclam_update(download_path):
             f.write("\nDNSDatabaseInfo current.cvd.clamav.net")
             f.write("\nDatabaseMirror  database.clamav.net")
             f.write("\nReceiveTimeout  0")
+            f.write("\nCompressLocalDatabase  true")
     try:
         command = [
             "freshclam",

--- a/src/index.ts
+++ b/src/index.ts
@@ -92,7 +92,7 @@ export interface ServerlessClamscanProps {
   The construct creates a Lambda function with EFS integration to support larger files.
   A VPC with isolated subnets, a S3 Gateway endpoint will also be created.
 
-  Additionally creates an hourly job to download the latest ClamAV definition files to the
+  Additionally creates an twice-daily job to download the latest ClamAV definition files to the
   Virus Definitions S3 Bucket by utilizing an EventBridge rule and a Lambda function and
   publishes CloudWatch Metrics to the 'serverless-clamscan' namespace.
 
@@ -418,7 +418,7 @@ export class ServerlessClamscan extends Construct {
     defs_bucket.grantReadWrite(download_defs);
 
     new Rule(this, 'VirusDefsUpdateRule', {
-      schedule: Schedule.rate(Duration.hours(1)),
+      schedule: Schedule.rate(Duration.hours(12)),
       targets: [new LambdaFunction(download_defs)],
     });
 


### PR DESCRIPTION
Closes #118 

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*