### PR TITLE
feat: Reserved concurrency for scan lambda

### DIFF
--- a/API.md
+++ b/API.md
@@ -69,6 +69,7 @@ new ServerlessClamscan(scope: Construct, id: string, props: ServerlessClamscanPr
   * **efsEncryption** (<code>boolean</code>)  Whether or not to enable encryption on EFS filesystem (Default: enabled). __*Optional*__
   * **onError** (<code>[IDestination](#aws-cdk-aws-lambda-idestination)</code>)  The Lambda Destination for files that fail to scan and are marked 'ERROR' or stuck 'IN PROGRESS' due to a Lambda timeout (Default: Creates and publishes to a new SQS queue if unspecified). __*Optional*__
   * **onResult** (<code>[IDestination](#aws-cdk-aws-lambda-idestination)</code>)  The Lambda Destination for files marked 'CLEAN' or 'INFECTED' based on the ClamAV Virus scan or 'N/A' for scans triggered by S3 folder creation events marked (Default: Creates and publishes to a new Event Bridge Bus if unspecified). __*Optional*__
+  * **reservedConcurrency** (<code>number</code>)  Optionally set a reserved concurrency for the virus scanning Lambda. __*Optional*__
 
 
 
@@ -135,6 +136,7 @@ Name | Type | Description
 **efsEncryption**? | <code>boolean</code> | Whether or not to enable encryption on EFS filesystem (Default: enabled).<br/>__*Optional*__
 **onError**? | <code>[IDestination](#aws-cdk-aws-lambda-idestination)</code> | The Lambda Destination for files that fail to scan and are marked 'ERROR' or stuck 'IN PROGRESS' due to a Lambda timeout (Default: Creates and publishes to a new SQS queue if unspecified).<br/>__*Optional*__
 **onResult**? | <code>[IDestination](#aws-cdk-aws-lambda-idestination)</code> | The Lambda Destination for files marked 'CLEAN' or 'INFECTED' based on the ClamAV Virus scan or 'N/A' for scans triggered by S3 folder creation events marked (Default: Creates and publishes to a new Event Bridge Bus if unspecified).<br/>__*Optional*__
+**reservedConcurrency**? | <code>number</code> | Optionally set a reserved concurrency for the virus scanning Lambda.<br/>__*Optional*__
 
 
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -69,6 +69,11 @@ export interface ServerlessClamscanProps {
    */
   readonly buckets?: Bucket[];
   /**
+   * Optionally set a reserved concurrency for the virus scanning Lambda.
+   * @see https://docs.aws.amazon.com/lambda/latest/operatorguide/reserved-concurrency.html
+   */
+  readonly reservedConcurrency?: number;
+  /**
    * The Lambda Destination for files marked 'CLEAN' or 'INFECTED' based on the ClamAV Virus scan or 'N/A' for scans triggered by S3 folder creation events marked (Default: Creates and publishes to a new Event Bridge Bus if unspecified).
    */
   readonly onResult?: IDestination;
@@ -387,6 +392,7 @@ export class ServerlessClamscan extends Construct {
       allowAllOutbound: false,
       timeout: Duration.minutes(15),
       memorySize: 10240,
+      reservedConcurrentExecutions: props.reservedConcurrency,
       environment: {
         EFS_MOUNT_PATH: this._efsMountPath,
         EFS_DEF_PATH: this._efsDefsPath,

--- a/test/ServerlessClamscan.test.ts
+++ b/test/ServerlessClamscan.test.ts
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { ABSENT, arrayWith, stringLike } from '@aws-cdk/assert';
+import { ABSENT, anything, arrayWith, stringLike } from '@aws-cdk/assert';
 import { EventBus } from '@aws-cdk/aws-events';
 import { SqsDestination, EventBridgeDestination } from '@aws-cdk/aws-lambda-destinations';
 import { Bucket } from '@aws-cdk/aws-s3';
@@ -164,6 +164,24 @@ test('expect VirusDefsBucket to not have access logging enabled', () => {
   });
   expect(stack).toHaveResourceLike('AWS::S3::Bucket', {
     LoggingConfiguration: ABSENT,
+  });
+});
+
+test('expect reserved concurrency prop to set scan Lambda reserved concurrency', () => {
+  const stack = new Stack();
+  new ServerlessClamscan(stack, 'default', {
+    reservedConcurrency: 100,
+  });
+  expect(stack).toHaveResourceLike('AWS::Lambda::Function', {
+    ReservedConcurrentExecutions: 100,
+  });
+});
+
+test('expect no reserved concurrency settings by default', () => {
+  const stack = new Stack();
+  new ServerlessClamscan(stack, 'default', {});
+  expect(stack).not.toHaveResourceLike('AWS::Lambda::Function', {
+    ReservedConcurrentExecutions: anything(),
   });
 });
 


### PR DESCRIPTION
Having unreserved lambda concurrency for scan may cause using all of the concurrency from unreserved pool. 
Which may affect rest of the lambdas. 

https://docs.aws.amazon.com/lambda/latest/dg/configuration-concurrency.html
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*