### PR TITLE
fix: VirusDefsBucket logs bucket not allowing for imported buckets

### DIFF
--- a/API.md
+++ b/API.md
@@ -81,7 +81,7 @@ Name | Type | Description
 **errorDest** | <code>[IDestination](#aws-cdk-aws-lambda-idestination)</code> | The Lambda Destination for failed on erred scans [ERROR, IN PROGRESS (If error is due to Lambda timeout)].
 **resultDest** | <code>[IDestination](#aws-cdk-aws-lambda-idestination)</code> | The Lambda Destination for completed ClamAV scans [CLEAN, INFECTED].
 **cleanRule**? | <code>[Rule](#aws-cdk-aws-events-rule)</code> | Conditional: An Event Bridge Rule for files that are marked 'CLEAN' by ClamAV if a success destination was not specified.<br/>__*Optional*__
-**defsAccessLogsBucket**? | <code>[Bucket](#aws-cdk-aws-s3-bucket)</code> | Conditional: The Bucket for access logs for the virus definitions bucket if logging is enabled (defsBucketAccessLogsConfig).<br/>__*Optional*__
+**defsAccessLogsBucket**? | <code>[IBucket](#aws-cdk-aws-s3-ibucket)</code> | Conditional: The Bucket for access logs for the virus definitions bucket if logging is enabled (defsBucketAccessLogsConfig).<br/>__*Optional*__
 **errorDeadLetterQueue**? | <code>[Queue](#aws-cdk-aws-sqs-queue)</code> | Conditional: The SQS Dead Letter Queue for the errorQueue if a failure (onError) destination was not specified.<br/>__*Optional*__
 **errorQueue**? | <code>[Queue](#aws-cdk-aws-sqs-queue)</code> | Conditional: The SQS Queue for erred scans if a failure (onError) destination was not specified.<br/>__*Optional*__
 **infectedRule**? | <code>[Rule](#aws-cdk-aws-events-rule)</code> | Conditional: An Event Bridge Rule for files that are marked 'INFECTED' by ClamAV if a success destination was not specified.<br/>__*Optional*__
@@ -117,7 +117,7 @@ Interface for ServerlessClamscan Virus Definitions S3 Bucket Logging.
 
 Name | Type | Description 
 -----|------|-------------
-**logsBucket**? | <code>boolean &#124; [Bucket](#aws-cdk-aws-s3-bucket)</code> | Destination bucket for the server access logs (Default: Creates a new S3 Bucket for access logs ).<br/>__*Optional*__
+**logsBucket**? | <code>boolean &#124; [IBucket](#aws-cdk-aws-s3-ibucket)</code> | Destination bucket for the server access logs (Default: Creates a new S3 Bucket for access logs ).<br/>__*Optional*__
 **logsPrefix**? | <code>string</code> | Optional log file prefix to use for the bucket's access logs, option is ignored if logs_bucket is set to false.<br/>__*Optional*__
 
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,7 +34,7 @@ import {
   SqsDestination,
 } from '@aws-cdk/aws-lambda-destinations';
 import { S3EventSource } from '@aws-cdk/aws-lambda-event-sources';
-import { Bucket, BucketEncryption, EventType } from '@aws-cdk/aws-s3';
+import { IBucket, Bucket, BucketEncryption, EventType } from '@aws-cdk/aws-s3';
 import { Queue, QueueEncryption } from '@aws-cdk/aws-sqs';
 import {
   Construct,
@@ -51,7 +51,7 @@ export interface ServerlessClamscanLoggingProps {
   /**
    * Destination bucket for the server access logs (Default: Creates a new S3 Bucket for access logs ).
    */
-  readonly logsBucket?: boolean | Bucket;
+  readonly logsBucket?: boolean | IBucket;
   /**
    * Optional log file prefix to use for the bucket's access logs, option is ignored if logs_bucket is set to false.
    */
@@ -162,7 +162,7 @@ export class ServerlessClamscan extends Construct {
   /**
     Conditional: The Bucket for access logs for the virus definitions bucket if logging is enabled (defsBucketAccessLogsConfig).
    */
-  public readonly defsAccessLogsBucket?: Bucket;
+  public readonly defsAccessLogsBucket?: IBucket;
 
   private _scanFunction: DockerImageFunction;
   private _s3Gw: GatewayVpcEndpoint;

--- a/test/ServerlessClamscan.test.ts
+++ b/test/ServerlessClamscan.test.ts
@@ -6,7 +6,7 @@ import { EventBus } from '@aws-cdk/aws-events';
 import { SqsDestination, EventBridgeDestination } from '@aws-cdk/aws-lambda-destinations';
 import { Bucket } from '@aws-cdk/aws-s3';
 import { Queue } from '@aws-cdk/aws-sqs';
-import { CfnOutput, Fn, Stack } from '@aws-cdk/core';
+import { Stack } from '@aws-cdk/core';
 import { ServerlessClamscan } from '../src';
 import '@aws-cdk/assert/jest';
 
@@ -134,10 +134,6 @@ test('expect VirusDefsBucket to use provided logs bucket', () => {
   new ServerlessClamscan(stack, 'default', {
     defsBucketAccessLogsConfig: { logsBucket: logs_bucket },
   });
-  new CfnOutput(stack, 'rLogsBucketArnExport', {
-    value: logs_bucket.bucketArn,
-    exportName: 'rLogsBucketArn',
-  });
 
   expect(stack).toHaveResourceLike('AWS::S3::Bucket', {
     LoggingConfiguration: {
@@ -162,37 +158,14 @@ test('expect VirusDefsBucket to use provided logs bucket', () => {
   });
 
   const stack3 = new Stack();
-  const imported_logs_bucket = Bucket.fromBucketArn(stack3, 'rImportedLogsBucket', Fn.importValue('rLogsBucketArn'));
   new ServerlessClamscan(stack3, 'default', {
-    defsBucketAccessLogsConfig: { logsBucket: imported_logs_bucket },
+    defsBucketAccessLogsConfig: {
+      logsBucket: Bucket.fromBucketName(stack3, 'rImportedLogsBucket', 'imported'),
+    },
   });
   expect(stack3).toHaveResourceLike('AWS::S3::Bucket', {
     LoggingConfiguration: {
-      DestinationBucketName:
-      {
-        'Fn::Select': [
-          0,
-          {
-            'Fn::Split': [
-              '/',
-              {
-                'Fn::Select': [
-                  5,
-                  {
-                    'Fn::Split': [
-                      ':',
-                      {
-                        'Fn::ImportValue': stringLike('*rLogsBucket*'),
-                      },
-                    ],
-                  },
-                ],
-              },
-            ],
-          },
-        ],
-      },
-      LogFilePrefix: ABSENT,
+      DestinationBucketName: 'imported',
     },
   });
 });


### PR DESCRIPTION
Fixes #370

Changing the type for VirusDefsBucket logs bucket from [Bucket](https://docs.aws.amazon.com/cdk/api/v1/docs/@aws-cdk_aws-s3.Bucket.html) to [IBucket](https://docs.aws.amazon.com/cdk/api/v1/docs/@aws-cdk_aws-s3.IBucket.html)
to allow capability to pass bucket imported from another stack.

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*