### PR TITLE
feat: support use of existing buckets as sources

### DIFF
--- a/API.md
+++ b/API.md
@@ -64,7 +64,8 @@ new ServerlessClamscan(scope: Construct, id: string, props: ServerlessClamscanPr
 * **scope** (<code>[Construct](#constructs-construct)</code>)  The parent creating construct (usually `this`).
 * **id** (<code>string</code>)  The construct's name.
 * **props** (<code>[ServerlessClamscanProps](#cdk-serverless-clamscan-serverlessclamscanprops)</code>)  A `ServerlessClamscanProps` interface.
-  * **buckets** (<code>Array<[aws_s3.Bucket](#aws-cdk-lib-aws-s3-bucket)></code>)  An optional list of S3 buckets to configure for ClamAV Virus Scanning; __*Optional*__
+  * **acceptResponsibilityForUsingExistingBucket** (<code>boolean</code>)  Allow reusing existing buckets which are not created in the CDK project. __*Optional*__
+  * **buckets** (<code>Array<[aws_s3.IBucket](#aws-cdk-lib-aws-s3-ibucket)></code>)  An optional list of S3 buckets to configure for ClamAV Virus Scanning; __*Optional*__
   * **defsBucketAccessLogsConfig** (<code>[ServerlessClamscanLoggingProps](#cdk-serverless-clamscan-serverlessclamscanloggingprops)</code>)  Whether or not to enable Access Logging for the Virus Definitions bucket, you can specify an existing bucket and prefix (Default: Creates a new S3 Bucket for access logs ). __*Optional*__
   * **efsEncryption** (<code>boolean</code>)  Whether or not to enable encryption on EFS filesystem (Default: enabled). __*Optional*__
   * **onError** (<code>[aws_lambda.IDestination](#aws-cdk-lib-aws-lambda-idestination)</code>)  The Lambda Destination for files that fail to scan and are marked 'ERROR' or stuck 'IN PROGRESS' due to a Lambda timeout (Default: Creates and publishes to a new SQS queue if unspecified). __*Optional*__
@@ -80,12 +81,14 @@ Name | Type | Description
 -----|------|-------------
 **errorDest** | <code>[aws_lambda.IDestination](#aws-cdk-lib-aws-lambda-idestination)</code> | The Lambda Destination for failed on erred scans [ERROR, IN PROGRESS (If error is due to Lambda timeout)].
 **resultDest** | <code>[aws_lambda.IDestination](#aws-cdk-lib-aws-lambda-idestination)</code> | The Lambda Destination for completed ClamAV scans [CLEAN, INFECTED].
+**scanAssumedPrincipal** | <code>[aws_iam.ArnPrincipal](#aws-cdk-lib-aws-iam-arnprincipal)</code> | <span></span>
 **cleanRule**? | <code>[aws_events.Rule](#aws-cdk-lib-aws-events-rule)</code> | Conditional: An Event Bridge Rule for files that are marked 'CLEAN' by ClamAV if a success destination was not specified.<br/>__*Optional*__
 **defsAccessLogsBucket**? | <code>[aws_s3.IBucket](#aws-cdk-lib-aws-s3-ibucket)</code> | Conditional: The Bucket for access logs for the virus definitions bucket if logging is enabled (defsBucketAccessLogsConfig).<br/>__*Optional*__
 **errorDeadLetterQueue**? | <code>[aws_sqs.Queue](#aws-cdk-lib-aws-sqs-queue)</code> | Conditional: The SQS Dead Letter Queue for the errorQueue if a failure (onError) destination was not specified.<br/>__*Optional*__
 **errorQueue**? | <code>[aws_sqs.Queue](#aws-cdk-lib-aws-sqs-queue)</code> | Conditional: The SQS Queue for erred scans if a failure (onError) destination was not specified.<br/>__*Optional*__
 **infectedRule**? | <code>[aws_events.Rule](#aws-cdk-lib-aws-events-rule)</code> | Conditional: An Event Bridge Rule for files that are marked 'INFECTED' by ClamAV if a success destination was not specified.<br/>__*Optional*__
 **resultBus**? | <code>[aws_events.EventBus](#aws-cdk-lib-aws-events-eventbus)</code> | Conditional: The Event Bridge Bus for completed ClamAV scans if a success (onResult) destination was not specified.<br/>__*Optional*__
+**useExternalBuckets**? | <code>boolean</code> | Conditional: When true, the user accepted the responsibility for using external buckets.<br/>__*Optional*__
 
 ### Methods
 
@@ -98,13 +101,26 @@ Grants the ClamAV function permissions to get and tag objects.
 Adds a bucket policy to disallow GetObject operations on files that are tagged 'IN PROGRESS', 'INFECTED', or 'ERROR'.
 
 ```ts
-addSourceBucket(bucket: Bucket): void
+addSourceBucket(bucket: IBucket): void
 ```
 
-* **bucket** (<code>[aws_s3.Bucket](#aws-cdk-lib-aws-s3-bucket)</code>)  The bucket to add the scanning bucket policy and s3:ObjectCreate* trigger to.
+* **bucket** (<code>[aws_s3.IBucket](#aws-cdk-lib-aws-s3-ibucket)</code>)  The bucket to add the scanning bucket policy and s3:ObjectCreate* trigger to.
 
 
 
+
+#### getPolicyStatementForBucket(bucket) <a id="cdk-serverless-clamscan-serverlessclamscan-getpolicystatementforbucket"></a>
+
+Returns the statement that should be added to the bucket policy in order to prevent objects to be accessed when they are not clean or there have been scanning errors: this policy should be added manually if external buckets are passed to addSourceBucket().
+
+```ts
+getPolicyStatementForBucket(bucket: IBucket): PolicyStatement
+```
+
+* **bucket** (<code>[aws_s3.IBucket](#aws-cdk-lib-aws-s3-ibucket)</code>)  The bucket which you need to protect with the policy.
+
+__Returns__:
+* <code>[aws_iam.PolicyStatement](#aws-cdk-lib-aws-iam-policystatement)</code>
 
 
 
@@ -131,7 +147,8 @@ Interface for creating a ServerlessClamscan.
 
 Name | Type | Description 
 -----|------|-------------
-**buckets**? | <code>Array<[aws_s3.Bucket](#aws-cdk-lib-aws-s3-bucket)></code> | An optional list of S3 buckets to configure for ClamAV Virus Scanning;<br/>__*Optional*__
+**acceptResponsibilityForUsingExistingBucket**? | <code>boolean</code> | Allow reusing existing buckets which are not created in the CDK project.<br/>__*Optional*__
+**buckets**? | <code>Array<[aws_s3.IBucket](#aws-cdk-lib-aws-s3-ibucket)></code> | An optional list of S3 buckets to configure for ClamAV Virus Scanning;<br/>__*Optional*__
 **defsBucketAccessLogsConfig**? | <code>[ServerlessClamscanLoggingProps](#cdk-serverless-clamscan-serverlessclamscanloggingprops)</code> | Whether or not to enable Access Logging for the Virus Definitions bucket, you can specify an existing bucket and prefix (Default: Creates a new S3 Bucket for access logs ).<br/>__*Optional*__
 **efsEncryption**? | <code>boolean</code> | Whether or not to enable encryption on EFS filesystem (Default: enabled).<br/>__*Optional*__
 **onError**? | <code>[aws_lambda.IDestination](#aws-cdk-lib-aws-lambda-idestination)</code> | The Lambda Destination for files that fail to scan and are marked 'ERROR' or stuck 'IN PROGRESS' due to a Lambda timeout (Default: Creates and publishes to a new SQS queue if unspecified).<br/>__*Optional*__

--- a/API.md
+++ b/API.md
@@ -64,7 +64,7 @@ new ServerlessClamscan(scope: Construct, id: string, props: ServerlessClamscanPr
 * **scope** (<code>[Construct](#constructs-construct)</code>)  The parent creating construct (usually `this`).
 * **id** (<code>string</code>)  The construct's name.
 * **props** (<code>[ServerlessClamscanProps](#cdk-serverless-clamscan-serverlessclamscanprops)</code>)  A `ServerlessClamscanProps` interface.
-  * **acceptResponsibilityForUsingExistingBucket** (<code>boolean</code>)  Allow reusing existing buckets which are not created in the CDK project. __*Optional*__
+  * **acceptResponsibilityForUsingImportedBucket** (<code>boolean</code>)  Allows the use of imported buckets. __*Optional*__
   * **buckets** (<code>Array<[aws_s3.IBucket](#aws-cdk-lib-aws-s3-ibucket)></code>)  An optional list of S3 buckets to configure for ClamAV Virus Scanning; __*Optional*__
   * **defsBucketAccessLogsConfig** (<code>[ServerlessClamscanLoggingProps](#cdk-serverless-clamscan-serverlessclamscanloggingprops)</code>)  Whether or not to enable Access Logging for the Virus Definitions bucket, you can specify an existing bucket and prefix (Default: Creates a new S3 Bucket for access logs ). __*Optional*__
   * **efsEncryption** (<code>boolean</code>)  Whether or not to enable encryption on EFS filesystem (Default: enabled). __*Optional*__
@@ -88,7 +88,7 @@ Name | Type | Description
 **errorQueue**? | <code>[aws_sqs.Queue](#aws-cdk-lib-aws-sqs-queue)</code> | Conditional: The SQS Queue for erred scans if a failure (onError) destination was not specified.<br/>__*Optional*__
 **infectedRule**? | <code>[aws_events.Rule](#aws-cdk-lib-aws-events-rule)</code> | Conditional: An Event Bridge Rule for files that are marked 'INFECTED' by ClamAV if a success destination was not specified.<br/>__*Optional*__
 **resultBus**? | <code>[aws_events.EventBus](#aws-cdk-lib-aws-events-eventbus)</code> | Conditional: The Event Bridge Bus for completed ClamAV scans if a success (onResult) destination was not specified.<br/>__*Optional*__
-**useExternalBuckets**? | <code>boolean</code> | Conditional: When true, the user accepted the responsibility for using external buckets.<br/>__*Optional*__
+**useImportedBuckets**? | <code>boolean</code> | Conditional: When true, the user accepted the responsibility for using imported buckets.<br/>__*Optional*__
 
 ### Methods
 
@@ -147,7 +147,7 @@ Interface for creating a ServerlessClamscan.
 
 Name | Type | Description 
 -----|------|-------------
-**acceptResponsibilityForUsingExistingBucket**? | <code>boolean</code> | Allow reusing existing buckets which are not created in the CDK project.<br/>__*Optional*__
+**acceptResponsibilityForUsingImportedBucket**? | <code>boolean</code> | Allows the use of imported buckets.<br/>__*Optional*__
 **buckets**? | <code>Array<[aws_s3.IBucket](#aws-cdk-lib-aws-s3-ibucket)></code> | An optional list of S3 buckets to configure for ClamAV Virus Scanning;<br/>__*Optional*__
 **defsBucketAccessLogsConfig**? | <code>[ServerlessClamscanLoggingProps](#cdk-serverless-clamscan-serverlessclamscanloggingprops)</code> | Whether or not to enable Access Logging for the Virus Definitions bucket, you can specify an existing bucket and prefix (Default: Creates a new S3 Bucket for access logs ).<br/>__*Optional*__
 **efsEncryption**? | <code>boolean</code> | Whether or not to enable encryption on EFS filesystem (Default: enabled).<br/>__*Optional*__

--- a/src/index.ts
+++ b/src/index.ts
@@ -90,7 +90,7 @@ export interface ServerlessClamscanProps {
   readonly defsBucketAccessLogsConfig?: ServerlessClamscanLoggingProps;
 
   /**
-   * Allow reusing existing buckets which are not created in the CDK project. When using external buckets the user is responsible for adding the required policy statement to the bucket policy: `getPolicyStatementForBucket()` can be used to retrieve the policy statement required by the solution.
+   * Allows the use of imported buckets. When using imported buckets the user is responsible for adding the required policy statement to the bucket policy: `getPolicyStatementForBucket()` can be used to retrieve the policy statement required by the solution.
    */
   readonly acceptResponsibilityForUsingImportedBucket?: boolean;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -573,7 +573,7 @@ export class ServerlessClamscan extends Construct {
    */
   addSourceBucket(bucket: IBucket) {
     if (!(bucket instanceof Bucket) && !this.useExternalBuckets) {
-      throw new Error('acceptResponsibilityForUsingExistingBucket must be set when adding an external bucket');
+      throw new Error("acceptResponsibilityForUsingImportedBucket must be set when adding an imported bucket. When using imported buckets the user is responsible for adding the required policy statement to the bucket policy: `getPolicyStatementForBucket()` can be used to retrieve the policy statement required by the solution");
     }
 
     this._scanFunction.addEventSource(

--- a/src/index.ts
+++ b/src/index.ts
@@ -171,7 +171,7 @@ export class ServerlessClamscan extends Construct {
   public readonly defsAccessLogsBucket?: IBucket;
 
   /**
-    Conditional: When true, the user accepted the responsibility for using external buckets
+    Conditional: When true, the user accepted the responsibility for using imported buckets
    */
   public readonly useImportedBuckets?: boolean;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -40,8 +40,8 @@ import {
   EventBridgeDestination,
   SqsDestination,
 } from 'aws-cdk-lib/aws-lambda-destinations';
-import { S3EventSource } from 'aws-cdk-lib/aws-lambda-event-sources';
 import { IBucket, Bucket, BucketEncryption, EventType } from 'aws-cdk-lib/aws-s3';
+import { LambdaDestination } from 'aws-cdk-lib/aws-s3-notifications';
 import { Queue, QueueEncryption } from 'aws-cdk-lib/aws-sqs';
 import { NagSuppressions } from 'cdk-nag';
 import { Construct } from 'constructs';
@@ -573,9 +573,11 @@ export class ServerlessClamscan extends Construct {
    * @param bucket The bucket to add the scanning bucket policy and s3:ObjectCreate* trigger to.
    */
   addSourceBucket(bucket: IBucket) {
-    this._scanFunction.addEventSource(
-      new S3EventSource(bucket as Bucket, { events: [EventType.OBJECT_CREATED] }),
+    bucket.addEventNotification(
+      EventType.OBJECT_CREATED,
+      new LambdaDestination(this._scanFunction),
     );
+
     bucket.grantRead(this._scanFunction);
     this._scanFunction.addToRolePolicy(
       new PolicyStatement({

--- a/src/index.ts
+++ b/src/index.ts
@@ -92,7 +92,7 @@ export interface ServerlessClamscanProps {
   /**
    * Allow reusing existing buckets which are not created in the CDK project. When using external buckets the user is responsible for adding the required policy statement to the bucket policy: `getPolicyStatementForBucket()` can be used to retrieve the policy statement required by the solution.
    */
-  readonly acceptResponsibilityForUsingExistingBucket?: boolean;
+  readonly acceptResponsibilityForUsingImportedBucket?: boolean;
 }
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -173,7 +173,7 @@ export class ServerlessClamscan extends Construct {
   /**
     Conditional: When true, the user accepted the responsibility for using external buckets
    */
-  public readonly useExternalBuckets?: boolean;
+  public readonly useImportedBuckets?: boolean;
 
   private _scanFunction: DockerImageFunction;
   private _s3Gw: GatewayVpcEndpoint;

--- a/test/ServerlessClamscan.test.ts
+++ b/test/ServerlessClamscan.test.ts
@@ -324,6 +324,8 @@ test('Check error is raised when imported bucket is used without accepting respo
   const stack = new Stack();
   const importedBucket = Bucket.fromBucketName(stack, 'ImportedBucket', 'imported-bucket-name');
 
+  const errorMessage = 'acceptResponsibilityForUsingImportedBucket must be set when adding an imported bucket. When using imported buckets the user is responsible for adding the required policy statement to the bucket policy: `getPolicyStatementForBucket()` can be used to retrieve the policy statement required by the solution';
+
   const f = () => {
     new ServerlessClamscan(stack, 'default', {
       buckets: [importedBucket],
@@ -331,12 +333,12 @@ test('Check error is raised when imported bucket is used without accepting respo
   };
 
   const g = () => {
-    const sc = new ServerlessClamscan(stack, 'default', {});
+    const sc = new ServerlessClamscan(stack, 'default_2', {});
     sc.addSourceBucket(importedBucket);
   };
 
-  expect(f).toThrow(Error);
-  expect(g).toThrow(Error);
+  expect(f).toThrow(errorMessage);
+  expect(g).toThrow(errorMessage);
 });
 
 test('check Virus Definition buckets policy security and S3 Gateway endpoint policy', () => {

--- a/test/ServerlessClamscan.test.ts
+++ b/test/ServerlessClamscan.test.ts
@@ -287,7 +287,7 @@ test('Check bucket triggers and policies for external bucket', () => {
   const externalBucket = Bucket.fromBucketName(stack, 'ExternalBucket', 'external-bucket-name');
   new ServerlessClamscan(stack, 'default', {
     buckets: [externalBucket],
-    acceptResponsibilityForUsingExistingBucket: true,
+    acceptResponsibilityForUsingImportedBucket: true,
   });
 
   // policy for the source bucket shouldn't be added

--- a/test/ServerlessClamscan.test.ts
+++ b/test/ServerlessClamscan.test.ts
@@ -282,11 +282,11 @@ test('check bucket triggers and policies for source buckets ', () => {
   });
 });
 
-test('Check bucket triggers and policies for external bucket', () => {
+test('Check bucket triggers and policies for imported bucket', () => {
   const stack = new Stack();
-  const externalBucket = Bucket.fromBucketName(stack, 'ExternalBucket', 'external-bucket-name');
+  const importedBucket = Bucket.fromBucketName(stack, 'ImportedBucket', 'imported-bucket-name');
   new ServerlessClamscan(stack, 'default', {
-    buckets: [externalBucket],
+    buckets: [importedBucket],
     acceptResponsibilityForUsingImportedBucket: true,
   });
 
@@ -313,11 +313,30 @@ test('Check bucket triggers and policies for external bucket', () => {
           {
             Ref: 'AWS::Partition',
           },
-          ':s3:::external-bucket-name',
+          ':s3:::imported-bucket-name',
         ],
       ],
     },
   });
+});
+
+test('Check error is raised when imported bucket is used without accepting responsibility', () => {
+  const stack = new Stack();
+  const importedBucket = Bucket.fromBucketName(stack, 'ImportedBucket', 'imported-bucket-name');
+
+  const f = () => {
+    new ServerlessClamscan(stack, 'default', {
+      buckets: [importedBucket],
+    });
+  };
+
+  const g = () => {
+    const sc = new ServerlessClamscan(stack, 'default', {});
+    sc.addSourceBucket(importedBucket);
+  };
+
+  expect(f).toThrow(Error);
+  expect(g).toThrow(Error);
 });
 
 test('check Virus Definition buckets policy security and S3 Gateway endpoint policy', () => {


### PR DESCRIPTION
Fix #451 

Passing an existing bucket to the construct is now supported, but the user must explicitly set the `acceptResponsibilityForUsingExistingBucket` or an error is thrown. When using an existing bucket, the bucket policy is not added automatically, but the relevant statement can be retrieved with `getPolicyStatementForBucket(bucket)` and the user is responsible to add that statement to the bucket. That can be done in different ways, but choice and responsibility is left to the user. For example a `CfnOutput` containing the policy statement can be created to expose the statement, or the policy can be explicitly replaced in the CDK project.

Edit: push-forced to fix invalid commit name

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*