### PR TITLE
feat: update docker images to use public.ecr.aws/lambda/python:3.11

### DIFF
--- a/assets/lambda/code/download_defs/Dockerfile
+++ b/assets/lambda/code/download_defs/Dockerfile
@@ -1,14 +1,12 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-FROM --platform=linux/amd64 public.ecr.aws/lambda/python:3.8
+FROM --platform=linux/amd64 public.ecr.aws/lambda/python:3.11
 LABEL name=lambda/python/clamav
 LABEL version=1.0
 
 ARG CACHE_DATE=1
 RUN yum update -y \
-    && yum install -y amazon-linux-extras \
-    && PYTHON=python2 amazon-linux-extras install epel \
     && yum -y install clamav clamd \
     && yum clean all \
     && pip3 install --no-cache-dir cffi awslambdaric boto3 requests aws-lambda-powertools \

--- a/assets/lambda/code/scan/Dockerfile
+++ b/assets/lambda/code/scan/Dockerfile
@@ -1,14 +1,12 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-FROM --platform=linux/amd64 public.ecr.aws/lambda/python:3.8
+FROM --platform=linux/amd64 public.ecr.aws/lambda/python:3.11
 LABEL name=lambda/python/clamav
 LABEL version=1.0
 
 ARG CACHE_DATE=1
 RUN yum update -y \
-    && yum install -y amazon-linux-extras \
-    && PYTHON=python2 amazon-linux-extras install epel \
     && yum -y install clamav clamd p7zip \
     && yum clean all \
     && pip3 install --no-cache-dir cffi awslambdaric boto3 requests aws-lambda-powertools \


### PR DESCRIPTION
The old container images used `clamav` from the `epel` repository. Newer versions  of the  `public.ecr.aws/lambda/python:3.8` use Amazon Linux 2023 which does not support the epel repository.  These changes  upgrade the image to use `public.ecr.aws/lambda/python:3.11` and use the `clamav` package from the `Amazon Lniux 2023` repository instead.


----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*