### PR TITLE
fix: pin lambda/python image to avoid breaking changes

### DIFF
--- a/assets/lambda/code/download_defs/Dockerfile
+++ b/assets/lambda/code/download_defs/Dockerfile
@@ -1,7 +1,7 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-FROM --platform=linux/amd64 public.ecr.aws/lambda/python:3.11
+FROM --platform=linux/amd64 public.ecr.aws/lambda/python:3.11.2023.11.18.02
 LABEL name=lambda/python/clamav
 LABEL version=1.0
 

--- a/assets/lambda/code/scan/Dockerfile
+++ b/assets/lambda/code/scan/Dockerfile
@@ -1,7 +1,7 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-FROM --platform=linux/amd64 public.ecr.aws/lambda/python:3.11
+FROM --platform=linux/amd64 public.ecr.aws/lambda/python:3.11.2023.11.18.02
 LABEL name=lambda/python/clamav
 LABEL version=1.0
 


### PR DESCRIPTION
As per the comments in #1046 and #1045, AWS has introduced breaking changes to the `public.ecr.aws/lambda/python:3.11` image.
This PR pins the image to a known-good image.

An ideal solution would be to update the use of `yum` to `dnf`, in line with AWS's suggestion, but even this has issues on the latest `3.11` image (see https://github.com/awslabs/cdk-serverless-clamscan/issues/1046#issuecomment-1842675868)

Fixes #1046

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*