### PR TITLE
fix: errors with expanding archival files

### DIFF
--- a/assets/lambda/code/download_defs/Dockerfile
+++ b/assets/lambda/code/download_defs/Dockerfile
@@ -1,14 +1,14 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-FROM --platform=linux/amd64 public.ecr.aws/lambda/python:3.11.2023.11.18.02
+FROM --platform=linux/amd64 public.ecr.aws/lambda/python:3.12
 LABEL name=lambda/python/clamav
 LABEL version=1.0
 
 ARG CACHE_DATE=1
-RUN yum update -y \
-    && yum -y install clamav clamd \
-    && yum clean all \
+RUN dnf update -y \
+    && dnf -y install clamav clamav-update clamd \
+    && dnf clean all \
     && pip3 install --no-cache-dir cffi awslambdaric boto3 requests aws-lambda-powertools \
     && ln -s /etc/freshclam.conf /tmp/freshclam.conf
 

--- a/assets/lambda/code/scan/Dockerfile
+++ b/assets/lambda/code/scan/Dockerfile
@@ -1,14 +1,14 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-FROM --platform=linux/amd64 public.ecr.aws/lambda/python:3.11.2023.11.18.02
+FROM --platform=linux/amd64 public.ecr.aws/lambda/python:3.12
 LABEL name=lambda/python/clamav
 LABEL version=1.0
 
 ARG CACHE_DATE=1
-RUN yum update -y \
-    && yum -y install clamav clamd p7zip \
-    && yum clean all \
+RUN dnf update -y \
+    && dnf -y install clamav clamav-update clamd p7zip \
+    && dnf clean all \
     && pip3 install --no-cache-dir cffi awslambdaric boto3 requests aws-lambda-powertools \
     && ln -s /etc/freshclam.conf /tmp/freshclam.conf
 


### PR DESCRIPTION
Fixes #1130, #1084

The `p7zip` utility was removed from the `amzn2-core` yum repository used in the python3.11 lambda docker image. The `dnf` repository in the newer python3.12 lambda docker image contains `p7zip`.

Switching to the 3.12 image to resolve this issue

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*