### PR TITLE
fix: allow for pnpm usage

### DIFF
--- a/.projenrc.js
+++ b/.projenrc.js
@@ -14,7 +14,6 @@ const project = new awscdk.AwsCdkConstructLibrary({
   repositoryUrl: 'https://github.com/awslabs/cdk-serverless-clamscan',
   description: 'Serverless architecture to virus scan objects in Amazon S3.',
   devDeps: ['@aws-cdk/assert@^2.11', 'cdk-nag@^2.15.18'],
-  bin: ['./assets'],
   keywords: [
     'clamav',
     'virus scan',

--- a/package.json
+++ b/package.json
@@ -5,9 +5,6 @@
     "type": "git",
     "url": "https://github.com/awslabs/cdk-serverless-clamscan"
   },
-  "bin": {
-    "0": "./assets"
-  },
   "scripts": {
     "build": "npx projen build",
     "bump": "npx projen bump",


### PR DESCRIPTION
The library  incorrectly used the `bin` folder for including additional assets such as lambda functions. This is unnecessary and caused issues for package managers like pnpm

Fixes https://github.com/awslabs/cdk-serverless-clamscan/issues/737 

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*