### PR TITLE
fix: Delete download path after scanning finished

### DIFF
--- a/assets/lambda/code/scan/lambda.py
+++ b/assets/lambda/code/scan/lambda.py
@@ -315,7 +315,8 @@ def delete(download_path, input_key=None):
                 shutil.rmtree(obj)
             else:
                 os.remove(obj)
-
+        # Remove the download_path folder itself
+        shutil.rmtree(download_path)
 
 def report_failure(input_bucket, input_key, download_path, message):
     """Set the S3 object tag to ERROR if scan function fails"""


### PR DESCRIPTION
----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

Issue: https://github.com/awslabs/cdk-serverless-clamscan/issues/1308. 
Plus, each empty directory takes 4KB on EFS and it might be a problem when EFS performs lifecycle transition to IA

Solution: Delete download path after scanning finished