### PR TITLE
feat: update Python runtime for init defs lambda

### DIFF
--- a/.projen/deps.json
+++ b/.projen/deps.json
@@ -97,7 +97,7 @@
     },
     {
       "name": "aws-cdk-lib",
-      "version": "^2.54.0",
+      "version": "^2.109.0",
       "type": "peer"
     },
     {

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -5,7 +5,7 @@ const AUTOMATION_TOKEN = 'PROJEN_GITHUB_TOKEN';
 const project = new awscdk.AwsCdkConstructLibrary({
   author: 'Amazon Web Services',
   authorAddress: 'donti@amazon.com',
-  cdkVersion: '2.54.0',
+  cdkVersion: '2.109.0',
   defaultReleaseBranch: 'main',
   majorVersion: 2,
   npmDistTag: 'latest',

--- a/assets/lambda/code/scan/lambda.py
+++ b/assets/lambda/code/scan/lambda.py
@@ -87,7 +87,9 @@ def lambda_handler(event, context):
             "status": ScanStatus.SKIP,
             "message": "S3 Event trigger was for a non-file object",
         }
-    elif (status := get_status(input_bucket, input_key, version_id)) == ScanStatus.SKIP:
+    elif (
+        status := get_status(input_bucket, input_key, version_id)
+    ) == ScanStatus.SKIP:
         summary = {
             "source": "serverless-clamscan",
             "input_bucket": input_bucket,
@@ -364,7 +366,9 @@ def freshclam_update(input_bucket, input_key, download_path, definitions_path):
                 stdout=subprocess.PIPE,
             )
             if update_summary.returncode == 0:
-                logger.info(f"Database update output: {update_summary.stdout.decode('utf-8')}")
+                logger.info(
+                    f"Database update output: {update_summary.stdout.decode('utf-8')}"
+                )
             else:
                 raise ClamAVException(
                     f"FreshClam exited with unexpected code: {update_summary.returncode}"

--- a/assets/lambda/code/scan/test_lambda.py
+++ b/assets/lambda/code/scan/test_lambda.py
@@ -95,7 +95,7 @@ def s3_event_unversioned():
 def s3_stubber():
     """Create and return a Stubber for the S3 client"""
     # Create a new S3 client for each test
-    s3_client = boto3.client('s3')
+    s3_client = boto3.client("s3")
     with Stubber(s3_client) as stubber:
         # Replace the global s3_client in the lambda module with our stubbed client
         original_client = scan_lambda.s3_client
@@ -117,7 +117,9 @@ class DummyContext:
     aws_request_id = "req-1"
     function_name = "test-function"
     memory_limit_in_mb = 512
-    invoked_function_arn = "arn:aws:lambda:us-east-1:123456789012:function:test-function"
+    invoked_function_arn = (
+        "arn:aws:lambda:us-east-1:123456789012:function:test-function"
+    )
 
 
 def test_set_status_versioned(s3_stubber):
@@ -129,17 +131,22 @@ def test_set_status_versioned(s3_stubber):
 
     # Stub the get_object_tagging call
     s3_stubber.add_response(
-        'get_object_tagging',
-        {'TagSet': []},
-        {'Bucket': bucket, 'Key': key, 'VersionId': version_id}
+        "get_object_tagging",
+        {"TagSet": []},
+        {"Bucket": bucket, "Key": key, "VersionId": version_id},
     )
 
     # Stub the put_object_tagging call
-    expected_tags = {'TagSet': [{'Key': 'scan-status', 'Value': status}]}
+    expected_tags = {"TagSet": [{"Key": "scan-status", "Value": status}]}
     s3_stubber.add_response(
-        'put_object_tagging',
+        "put_object_tagging",
         {},
-        {'Bucket': bucket, 'Key': key, 'Tagging': expected_tags, 'VersionId': version_id}
+        {
+            "Bucket": bucket,
+            "Key": key,
+            "Tagging": expected_tags,
+            "VersionId": version_id,
+        },
     )
 
     # Act
@@ -157,17 +164,15 @@ def test_set_status_unversioned(s3_stubber):
 
     # Stub the get_object_tagging call
     s3_stubber.add_response(
-        'get_object_tagging',
-        {'TagSet': []},
-        {'Bucket': bucket, 'Key': key}
+        "get_object_tagging", {"TagSet": []}, {"Bucket": bucket, "Key": key}
     )
 
     # Stub the put_object_tagging call
-    expected_tags = {'TagSet': [{'Key': 'scan-status', 'Value': status}]}
+    expected_tags = {"TagSet": [{"Key": "scan-status", "Value": status}]}
     s3_stubber.add_response(
-        'put_object_tagging',
+        "put_object_tagging",
         {},
-        {'Bucket': bucket, 'Key': key, 'Tagging': expected_tags}
+        {"Bucket": bucket, "Key": key, "Tagging": expected_tags},
     )
 
     # Act
@@ -186,9 +191,9 @@ def test_get_status_versioned_found(s3_stubber):
 
     # Stub the get_object_tagging call
     s3_stubber.add_response(
-        'get_object_tagging',
-        {'TagSet': [{'Key': 'scan-status', 'Value': expected_status}]},
-        {'Bucket': bucket, 'Key': key, 'VersionId': version_id}
+        "get_object_tagging",
+        {"TagSet": [{"Key": "scan-status", "Value": expected_status}]},
+        {"Bucket": bucket, "Key": key, "VersionId": version_id},
     )
 
     # Act
@@ -207,9 +212,9 @@ def test_get_status_unversioned_found(s3_stubber):
 
     # Stub the get_object_tagging call
     s3_stubber.add_response(
-        'get_object_tagging',
-        {'TagSet': [{'Key': 'scan-status', 'Value': expected_status}]},
-        {'Bucket': bucket, 'Key': key}
+        "get_object_tagging",
+        {"TagSet": [{"Key": "scan-status", "Value": expected_status}]},
+        {"Bucket": bucket, "Key": key},
     )
 
     # Act
@@ -227,18 +232,16 @@ def test_get_status_deleted(s3_stubber):
     version_id = "v1"
 
     # Stub the get_object_tagging call with an error
-    error_response = {
-        'Error': {
-            'Code': 'NoSuchKey',
-            'Message': 'Not found'
-        }
-    }
     s3_stubber.add_client_error(
-        'get_object_tagging',
-        service_error_code='NoSuchKey',
-        service_message='Not found',
+        "get_object_tagging",
+        service_error_code="NoSuchKey",
+        service_message="Not found",
         http_status_code=404,
-        expected_params={'Bucket': bucket, 'Key': key, 'VersionId': version_id}
+        expected_params={
+            "Bucket": bucket,
+            "Key": key,
+            "VersionId": version_id,
+        },
     )
 
     # Act
@@ -259,13 +262,15 @@ def test_get_tag_value_versioned(s3_stubber):
 
     # Stub the get_object_tagging call
     s3_stubber.add_response(
-        'get_object_tagging',
-        {'TagSet': [{'Key': 'foo', 'Value': expected_value}]},
-        {'Bucket': bucket, 'Key': key, 'VersionId': version_id}
+        "get_object_tagging",
+        {"TagSet": [{"Key": "foo", "Value": expected_value}]},
+        {"Bucket": bucket, "Key": key, "VersionId": version_id},
     )
 
     # Act
-    value = scan_lambda.get_tag_value(bucket, key, tag_key, version_id=version_id)
+    value = scan_lambda.get_tag_value(
+        bucket, key, tag_key, version_id=version_id
+    )
 
     # Assert
     assert_that(value).is_equal_to(expected_value)
@@ -280,9 +285,9 @@ def test_get_tag_value_not_found(s3_stubber):
 
     # Stub the get_object_tagging call
     s3_stubber.add_response(
-        'get_object_tagging',
-        {'TagSet': [{'Key': 'foo', 'Value': 'bar'}]},
-        {'Bucket': bucket, 'Key': key}
+        "get_object_tagging",
+        {"TagSet": [{"Key": "foo", "Value": "bar"}]},
+        {"Bucket": bucket, "Key": key},
     )
 
     # Act
@@ -332,28 +337,35 @@ def test_lambda_handler_versioned(
 
     # First, stub the get_object_tagging call for get_status
     s3_stubber.add_response(
-        'get_object_tagging',
-        {'TagSet': []},
-        {'Bucket': 'test-bucket', 'Key': 'test.txt', 'VersionId': 'abc123'}
+        "get_object_tagging",
+        {"TagSet": []},
+        {"Bucket": "test-bucket", "Key": "test.txt", "VersionId": "abc123"},
     )
 
     # Second, stub the get_object_tagging call for set_status
     s3_stubber.add_response(
-        'get_object_tagging',
-        {'TagSet': []},
-        {'Bucket': 'test-bucket', 'Key': 'test.txt', 'VersionId': 'abc123'}
+        "get_object_tagging",
+        {"TagSet": []},
+        {"Bucket": "test-bucket", "Key": "test.txt", "VersionId": "abc123"},
     )
 
     # Third, stub the put_object_tagging call for set_status
     s3_stubber.add_response(
-        'put_object_tagging',
+        "put_object_tagging",
         {},
         {
-            'Bucket': 'test-bucket',
-            'Key': 'test.txt',
-            'Tagging': {'TagSet': [{'Key': 'scan-status', 'Value': scan_lambda.ScanStatus.IN_PROGRESS}]},
-            'VersionId': 'abc123'
-        }
+            "Bucket": "test-bucket",
+            "Key": "test.txt",
+            "Tagging": {
+                "TagSet": [
+                    {
+                        "Key": "scan-status",
+                        "Value": scan_lambda.ScanStatus.IN_PROGRESS,
+                    }
+                ]
+            },
+            "VersionId": "abc123",
+        },
     )
 
     # Act
@@ -411,27 +423,34 @@ def test_lambda_handler_unversioned(
 
     # First, stub the get_object_tagging call for get_status
     s3_stubber.add_response(
-        'get_object_tagging',
-        {'TagSet': []},
-        {'Bucket': 'test-bucket', 'Key': 'test.txt'}
+        "get_object_tagging",
+        {"TagSet": []},
+        {"Bucket": "test-bucket", "Key": "test.txt"},
     )
 
     # Second, stub the get_object_tagging call for set_status
     s3_stubber.add_response(
-        'get_object_tagging',
-        {'TagSet': []},
-        {'Bucket': 'test-bucket', 'Key': 'test.txt'}
+        "get_object_tagging",
+        {"TagSet": []},
+        {"Bucket": "test-bucket", "Key": "test.txt"},
     )
 
     # Third, stub the put_object_tagging call for set_status
     s3_stubber.add_response(
-        'put_object_tagging',
+        "put_object_tagging",
         {},
         {
-            'Bucket': 'test-bucket',
-            'Key': 'test.txt',
-            'Tagging': {'TagSet': [{'Key': 'scan-status', 'Value': scan_lambda.ScanStatus.IN_PROGRESS}]}
-        }
+            "Bucket": "test-bucket",
+            "Key": "test.txt",
+            "Tagging": {
+                "TagSet": [
+                    {
+                        "Key": "scan-status",
+                        "Value": scan_lambda.ScanStatus.IN_PROGRESS,
+                    }
+                ]
+            },
+        },
     )
 
     # Act
@@ -479,7 +498,7 @@ def test_lambda_handler_directory_path(mock_add_metric, mock_flush_metrics):
     original_metrics = scan_lambda.metrics
     try:
         # Act
-        with patch.dict('os.environ', env_vars):
+        with patch.dict("os.environ", env_vars):
             # Set namespace directly before the test
             scan_lambda.metrics.namespace = "test-namespace"
             result = scan_lambda.lambda_handler(event, ctx)
@@ -494,7 +513,9 @@ def test_lambda_handler_directory_path(mock_add_metric, mock_flush_metrics):
 
 @patch("lambda.metrics.flush_metrics")
 @patch("lambda.metrics.add_metric")
-def test_lambda_handler_skip_status(mock_add_metric, mock_flush_metrics, s3_stubber):
+def test_lambda_handler_skip_status(
+    mock_add_metric, mock_flush_metrics, s3_stubber
+):
     # Arrange
     ctx = DummyContext()
     event = {
@@ -519,16 +540,20 @@ def test_lambda_handler_skip_status(mock_add_metric, mock_flush_metrics, s3_stub
 
     # Stub the get_object_tagging call for get_status
     s3_stubber.add_response(
-        'get_object_tagging',
-        {'TagSet': [{'Key': 'scan-status', 'Value': scan_lambda.ScanStatus.SKIP}]},
-        {'Bucket': 'test-bucket', 'Key': 'test.txt'}
+        "get_object_tagging",
+        {
+            "TagSet": [
+                {"Key": "scan-status", "Value": scan_lambda.ScanStatus.SKIP}
+            ]
+        },
+        {"Bucket": "test-bucket", "Key": "test.txt"},
     )
 
     # Create a mock metrics object
     original_metrics = scan_lambda.metrics
     try:
         # Act
-        with patch.dict('os.environ', env_vars):
+        with patch.dict("os.environ", env_vars):
             # Set namespace directly before the test
             scan_lambda.metrics.namespace = "test-namespace"
             result = scan_lambda.lambda_handler(event, ctx)
@@ -544,7 +569,9 @@ def test_lambda_handler_skip_status(mock_add_metric, mock_flush_metrics, s3_stub
 
 @patch("lambda.metrics.flush_metrics")
 @patch("lambda.metrics.add_metric")
-def test_lambda_handler_deleted_status(mock_add_metric, mock_flush_metrics, s3_stubber):
+def test_lambda_handler_deleted_status(
+    mock_add_metric, mock_flush_metrics, s3_stubber
+):
     # Arrange
     ctx = DummyContext()
     event = {
@@ -569,18 +596,18 @@ def test_lambda_handler_deleted_status(mock_add_metric, mock_flush_metrics, s3_s
 
     # Stub the get_object_tagging call for get_status with an error
     s3_stubber.add_client_error(
-        'get_object_tagging',
-        service_error_code='NoSuchKey',
-        service_message='Not found',
+        "get_object_tagging",
+        service_error_code="NoSuchKey",
+        service_message="Not found",
         http_status_code=404,
-        expected_params={'Bucket': 'test-bucket', 'Key': 'test.txt'}
+        expected_params={"Bucket": "test-bucket", "Key": "test.txt"},
     )
 
     # Create a mock metrics object
     original_metrics = scan_lambda.metrics
     try:
         # Act
-        with patch.dict('os.environ', env_vars):
+        with patch.dict("os.environ", env_vars):
             # Set namespace directly before the test
             scan_lambda.metrics.namespace = "test-namespace"
             result = scan_lambda.lambda_handler(event, ctx)
@@ -628,7 +655,7 @@ def test_create_dir_success(mock_makedirs, mock_exists):
 
 @patch("os.path.exists")
 @patch("os.makedirs")
-@patch.object(scan_lambda, 'report_failure')
+@patch.object(scan_lambda, "report_failure")
 def test_create_dir_error(mock_report_failure, mock_makedirs, mock_exists):
     # Arrange
     mock_exists.return_value = False
@@ -643,10 +670,12 @@ def test_create_dir_error(mock_report_failure, mock_makedirs, mock_exists):
     # Assert
     mock_exists.assert_called_once()
     mock_makedirs.assert_called_once_with(download_path, exist_ok=True)
-    mock_report_failure.assert_called_once_with(bucket, key, download_path, "Test error")
+    mock_report_failure.assert_called_once_with(
+        bucket, key, download_path, "Test error"
+    )
 
 
-@patch.object(scan_lambda.s3_client, 'download_file')
+@patch.object(scan_lambda.s3_client, "download_file")
 def test_download_object_success(mock_download_file):
     # Arrange
     bucket = "test-bucket"
@@ -662,12 +691,12 @@ def test_download_object_success(mock_download_file):
         Bucket=bucket,
         Key=key,
         Filename=f"{download_path}/{key}",
-        ExtraArgs={'VersionId': version_id},
+        ExtraArgs={"VersionId": version_id},
     )
 
 
-@patch.object(scan_lambda.s3_client, 'download_file')
-@patch.object(scan_lambda, 'report_failure')
+@patch.object(scan_lambda.s3_client, "download_file")
+@patch.object(scan_lambda, "report_failure")
 def test_download_object_error(mock_report_failure, mock_download_file):
     # Arrange
     bucket = "test-bucket"
@@ -693,7 +722,9 @@ def test_download_object_error(mock_report_failure, mock_download_file):
 def test_scan_clean_result(mock_run, s3_stubber):
     # Arrange
     mock_run.return_value.returncode = 0
-    mock_run.return_value.stdout = b"----------- SCAN SUMMARY -----------\nInfected files: 0\n"
+    mock_run.return_value.stdout = (
+        b"----------- SCAN SUMMARY -----------\nInfected files: 0\n"
+    )
     input_bucket = "test-bucket"
     input_key = "test-file.txt"
     download_path = tempfile.mkdtemp()
@@ -703,28 +734,44 @@ def test_scan_clean_result(mock_run, s3_stubber):
 
     # Stub the get_object_tagging call for set_status
     s3_stubber.add_response(
-        'get_object_tagging',
-        {'TagSet': []},
-        {'Bucket': input_bucket, 'Key': input_key, 'VersionId': version_id}
+        "get_object_tagging",
+        {"TagSet": []},
+        {"Bucket": input_bucket, "Key": input_key, "VersionId": version_id},
     )
 
     # Stub the put_object_tagging call for set_status
     s3_stubber.add_response(
-        'put_object_tagging',
+        "put_object_tagging",
         {},
         {
-            'Bucket': input_bucket,
-            'Key': input_key,
-            'Tagging': {'TagSet': [{'Key': 'scan-status', 'Value': scan_lambda.ScanStatus.CLEAN}]},
-            'VersionId': version_id
-        }
+            "Bucket": input_bucket,
+            "Key": input_key,
+            "Tagging": {
+                "TagSet": [
+                    {
+                        "Key": "scan-status",
+                        "Value": scan_lambda.ScanStatus.CLEAN,
+                    }
+                ]
+            },
+            "VersionId": version_id,
+        },
     )
 
     # Act
-    with patch.object(scan_lambda.metrics, 'add_metric'), \
-         patch.object(scan_lambda.metrics, 'flush_metrics'), \
-         patch.dict('os.environ', {'POWERTOOLS_METRICS_NAMESPACE': 'test-namespace'}):
-        result = scan_lambda.scan(input_bucket, input_key, download_path, definitions_path, tmp_path, version_id)
+    with patch.object(scan_lambda.metrics, "add_metric"), patch.object(
+        scan_lambda.metrics, "flush_metrics"
+    ), patch.dict(
+        "os.environ", {"POWERTOOLS_METRICS_NAMESPACE": "test-namespace"}
+    ):
+        result = scan_lambda.scan(
+            input_bucket,
+            input_key,
+            download_path,
+            definitions_path,
+            tmp_path,
+            version_id,
+        )
 
     # Assert
     assert_that(result).is_not_none()
@@ -736,8 +783,10 @@ def test_scan_clean_result(mock_run, s3_stubber):
 def test_scan_infected_result(mock_run, s3_stubber):
     # Arrange
     mock_run.return_value.returncode = 1
-    mock_run.return_value.stdout = (b"----------- SCAN SUMMARY -----------\nInfected files: "
-                                    b"1\n/tmp/path/test-file.txt: Eicar-Test-Signature FOUND\n")
+    mock_run.return_value.stdout = (
+        b"----------- SCAN SUMMARY -----------\nInfected files: "
+        b"1\n/tmp/path/test-file.txt: Eicar-Test-Signature FOUND\n"
+    )
     input_bucket = "test-bucket"
     input_key = "test-file.txt"
     download_path = tempfile.mkdtemp()
@@ -747,28 +796,44 @@ def test_scan_infected_result(mock_run, s3_stubber):
 
     # Stub the get_object_tagging call for set_status
     s3_stubber.add_response(
-        'get_object_tagging',
-        {'TagSet': []},
-        {'Bucket': input_bucket, 'Key': input_key, 'VersionId': version_id}
+        "get_object_tagging",
+        {"TagSet": []},
+        {"Bucket": input_bucket, "Key": input_key, "VersionId": version_id},
     )
 
     # Stub the put_object_tagging call for set_status
     s3_stubber.add_response(
-        'put_object_tagging',
+        "put_object_tagging",
         {},
         {
-            'Bucket': input_bucket,
-            'Key': input_key,
-            'Tagging': {'TagSet': [{'Key': 'scan-status', 'Value': scan_lambda.ScanStatus.INFECTED}]},
-            'VersionId': version_id
-        }
+            "Bucket": input_bucket,
+            "Key": input_key,
+            "Tagging": {
+                "TagSet": [
+                    {
+                        "Key": "scan-status",
+                        "Value": scan_lambda.ScanStatus.INFECTED,
+                    }
+                ]
+            },
+            "VersionId": version_id,
+        },
     )
 
     # Act
-    with patch.object(scan_lambda.metrics, 'add_metric'), \
-         patch.object(scan_lambda.metrics, 'flush_metrics'), \
-         patch.dict('os.environ', {'POWERTOOLS_METRICS_NAMESPACE': 'test-namespace'}):
-        result = scan_lambda.scan(input_bucket, input_key, download_path, definitions_path, tmp_path, version_id)
+    with patch.object(scan_lambda.metrics, "add_metric"), patch.object(
+        scan_lambda.metrics, "flush_metrics"
+    ), patch.dict(
+        "os.environ", {"POWERTOOLS_METRICS_NAMESPACE": "test-namespace"}
+    ):
+        result = scan_lambda.scan(
+            input_bucket,
+            input_key,
+            download_path,
+            definitions_path,
+            tmp_path,
+            version_id,
+        )
 
     # Assert
     assert_that(result).is_not_none()
@@ -780,7 +845,9 @@ def test_scan_infected_result(mock_run, s3_stubber):
 def test_scan_error_result(mock_run, s3_stubber):
     # Arrange
     mock_run.return_value.returncode = 2  # Error code
-    mock_run.return_value.stdout = b"----------- SCAN SUMMARY -----------\nError: Some error occurred\n"
+    mock_run.return_value.stdout = (
+        b"----------- SCAN SUMMARY -----------\nError: Some error occurred\n"
+    )
     input_bucket = "test-bucket"
     input_key = "test-file.txt"
     download_path = tempfile.mkdtemp()
@@ -789,32 +856,46 @@ def test_scan_error_result(mock_run, s3_stubber):
 
     # Stub the get_object_tagging call for set_status and report_failure
     s3_stubber.add_response(
-        'get_object_tagging',
-        {'TagSet': []},
-        {'Bucket': input_bucket, 'Key': input_key}
+        "get_object_tagging",
+        {"TagSet": []},
+        {"Bucket": input_bucket, "Key": input_key},
     )
 
     # Stub the put_object_tagging call for set_status and report_failure
     s3_stubber.add_response(
-        'put_object_tagging',
+        "put_object_tagging",
         {},
         {
-            'Bucket': input_bucket,
-            'Key': input_key,
-            'Tagging': {'TagSet': [{'Key': 'scan-status', 'Value': scan_lambda.ScanStatus.ERROR}]}
-        }
+            "Bucket": input_bucket,
+            "Key": input_key,
+            "Tagging": {
+                "TagSet": [
+                    {
+                        "Key": "scan-status",
+                        "Value": scan_lambda.ScanStatus.ERROR,
+                    }
+                ]
+            },
+        },
     )
 
     # Act & Assert
-    with patch.object(scan_lambda.metrics, 'add_metric'), \
-         patch.object(scan_lambda.metrics, 'flush_metrics'), \
-         patch.dict('os.environ', {'POWERTOOLS_METRICS_NAMESPACE': 'test-namespace'}), \
-         pytest.raises(Exception) as excinfo:
-        scan_lambda.scan(input_bucket, input_key, download_path, definitions_path, tmp_path)
-    
+    with patch.object(scan_lambda.metrics, "add_metric"), patch.object(
+        scan_lambda.metrics, "flush_metrics"
+    ), patch.dict(
+        "os.environ", {"POWERTOOLS_METRICS_NAMESPACE": "test-namespace"}
+    ), pytest.raises(
+        Exception
+    ) as excinfo:
+        scan_lambda.scan(
+            input_bucket, input_key, download_path, definitions_path, tmp_path
+        )
+
     # Verify exception contains expected data
     exception_data = json.loads(str(excinfo.value))
-    assert_that(exception_data["status"]).is_equal_to(scan_lambda.ScanStatus.ERROR)
+    assert_that(exception_data["status"]).is_equal_to(
+        scan_lambda.ScanStatus.ERROR
+    )
     assert_that(exception_data["input_bucket"]).is_equal_to(input_bucket)
     assert_that(exception_data["input_key"]).is_equal_to(input_key)
     assert_that(s3_stubber).has_no_pending_responses()
@@ -823,7 +904,9 @@ def test_scan_error_result(mock_run, s3_stubber):
 @patch("lambda.subprocess.run")
 def test_scan_subprocess_error(mock_run, s3_stubber):
     # Arrange
-    mock_run.side_effect = subprocess.CalledProcessError(1, "clamscan", output=b"Error output")
+    mock_run.side_effect = subprocess.CalledProcessError(
+        1, "clamscan", output=b"Error output"
+    )
     input_bucket = "test-bucket"
     input_key = "test-file.txt"
     download_path = tempfile.mkdtemp()
@@ -832,39 +915,53 @@ def test_scan_subprocess_error(mock_run, s3_stubber):
 
     # Stub the get_object_tagging call for set_status and report_failure
     s3_stubber.add_response(
-        'get_object_tagging',
-        {'TagSet': []},
-        {'Bucket': input_bucket, 'Key': input_key}
+        "get_object_tagging",
+        {"TagSet": []},
+        {"Bucket": input_bucket, "Key": input_key},
     )
 
     # Stub the put_object_tagging call for set_status and report_failure
     s3_stubber.add_response(
-        'put_object_tagging',
+        "put_object_tagging",
         {},
         {
-            'Bucket': input_bucket,
-            'Key': input_key,
-            'Tagging': {'TagSet': [{'Key': 'scan-status', 'Value': scan_lambda.ScanStatus.ERROR}]}
-        }
+            "Bucket": input_bucket,
+            "Key": input_key,
+            "Tagging": {
+                "TagSet": [
+                    {
+                        "Key": "scan-status",
+                        "Value": scan_lambda.ScanStatus.ERROR,
+                    }
+                ]
+            },
+        },
     )
 
     # Act & Assert
-    with patch.object(scan_lambda.metrics, 'add_metric'), \
-         patch.object(scan_lambda.metrics, 'flush_metrics'), \
-         patch.dict('os.environ', {'POWERTOOLS_METRICS_NAMESPACE': 'test-namespace'}), \
-         pytest.raises(Exception) as excinfo:
-        scan_lambda.scan(input_bucket, input_key, download_path, definitions_path, tmp_path)
-    
+    with patch.object(scan_lambda.metrics, "add_metric"), patch.object(
+        scan_lambda.metrics, "flush_metrics"
+    ), patch.dict(
+        "os.environ", {"POWERTOOLS_METRICS_NAMESPACE": "test-namespace"}
+    ), pytest.raises(
+        Exception
+    ) as excinfo:
+        scan_lambda.scan(
+            input_bucket, input_key, download_path, definitions_path, tmp_path
+        )
+
     # Verify exception contains expected data
     exception_data = json.loads(str(excinfo.value))
-    assert_that(exception_data["status"]).is_equal_to(scan_lambda.ScanStatus.ERROR)
+    assert_that(exception_data["status"]).is_equal_to(
+        scan_lambda.ScanStatus.ERROR
+    )
     assert_that(exception_data["input_bucket"]).is_equal_to(input_bucket)
     assert_that(exception_data["input_key"]).is_equal_to(input_key)
     assert_that(s3_stubber).has_no_pending_responses()
 
 
-@patch('os.path.exists')
-@patch('os.remove')
+@patch("os.path.exists")
+@patch("os.remove")
 def test_delete_file(mock_remove, mock_exists):
     # Arrange
     mock_exists.return_value = True
@@ -878,8 +975,8 @@ def test_delete_file(mock_remove, mock_exists):
     mock_remove.assert_called_once_with(f"{download_path}/{input_key}")
 
 
-@patch('os.path.exists')
-@patch('shutil.rmtree')
+@patch("os.path.exists")
+@patch("shutil.rmtree")
 def test_delete_directory(mock_rmtree, mock_exists):
     # Arrange
     mock_exists.return_value = True
@@ -894,9 +991,13 @@ def test_delete_directory(mock_rmtree, mock_exists):
 
 def test_report_failure():
     # Arrange
-    with patch.object(scan_lambda, 'set_status') as mock_set_status, \
-         patch.object(scan_lambda, 'delete') as mock_delete, \
-         patch.object(scan_lambda.logger, 'error') as mock_logger_error:
+    with patch.object(
+        scan_lambda, "set_status"
+    ) as mock_set_status, patch.object(
+        scan_lambda, "delete"
+    ) as mock_delete, patch.object(
+        scan_lambda.logger, "error"
+    ) as mock_logger_error:
         input_bucket = "test-bucket"
         input_key = "test-file.txt"
         download_path = tempfile.mkdtemp()
@@ -905,16 +1006,20 @@ def test_report_failure():
 
         # Act & Assert
         with pytest.raises(Exception) as excinfo:
-            scan_lambda.report_failure(input_bucket, input_key, download_path, message, version_id)
-        
+            scan_lambda.report_failure(
+                input_bucket, input_key, download_path, message, version_id
+            )
+
         # Verify exception contains expected data
         exception_data = json.loads(str(excinfo.value))
-        assert_that(exception_data["status"]).is_equal_to(scan_lambda.ScanStatus.ERROR)
+        assert_that(exception_data["status"]).is_equal_to(
+            scan_lambda.ScanStatus.ERROR
+        )
         assert_that(exception_data["input_bucket"]).is_equal_to(input_bucket)
         assert_that(exception_data["input_key"]).is_equal_to(input_key)
         assert_that(exception_data["message"]).is_equal_to(message)
         assert_that(exception_data["version_id"]).is_equal_to(version_id)
-        
+
         # Verify mocks were called
         mock_set_status.assert_called_once_with(
             input_bucket, input_key, scan_lambda.ScanStatus.ERROR, version_id

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@types/node": "^16 <= 16.18.78",
     "@typescript-eslint/eslint-plugin": "^8",
     "@typescript-eslint/parser": "^8",
-    "aws-cdk-lib": "2.54.0",
+    "aws-cdk-lib": "2.109.0",
     "cdk-nag": "^2.15.18",
     "commit-and-tag-version": "^12",
     "constructs": "10.0.5",
@@ -61,7 +61,7 @@
     "typescript": "^4.9.5"
   },
   "peerDependencies": {
-    "aws-cdk-lib": "^2.54.0",
+    "aws-cdk-lib": "^2.109.0",
     "constructs": "^10.0.5"
   },
   "resolutions": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -491,7 +491,7 @@ export class ServerlessClamscan extends Construct {
     });
 
     const init_defs_cr = new Function(this, 'InitDefs', {
-      runtime: Runtime.PYTHON_3_9,
+      runtime: Runtime.PYTHON_3_12,
       code: Code.fromAsset(
         path.join(__dirname, '../assets/lambda/code/initialize_defs_cr'),
       ),

--- a/yarn.lock
+++ b/yarn.lock
@@ -28,20 +28,20 @@
   dependencies:
     "@aws-cdk/cloudformation-diff" "2.68.0"
 
-"@aws-cdk/asset-awscli-v1@^2.2.16":
+"@aws-cdk/asset-awscli-v1@^2.2.201":
   version "2.2.249"
   resolved "https://registry.yarnpkg.com/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.249.tgz#75d67468bf3598470836a59453f13a785d7dc3fd"
   integrity sha512-VtTIdYPJ8SPvafsuGRBloaMwiKRBd6rgS8QGyTmsOnKbK4dWL24MA9hVJx3f+MX7J51F9FukPmaFmP4iuMarkA==
 
-"@aws-cdk/asset-kubectl-v20@^2.1.1":
+"@aws-cdk/asset-kubectl-v20@^2.1.2":
   version "2.1.4"
   resolved "https://registry.yarnpkg.com/@aws-cdk/asset-kubectl-v20/-/asset-kubectl-v20-2.1.4.tgz#5b76656f651a192e8d28766a5bdf04c444905363"
   integrity sha512-Ps2MkmjYgMyflagqQ4dgTElc7Vwpqj8spw8dQVFiSeaaMPsuDSNsPax3/HjuDuwqsmLdaCZc6umlxYLpL0kYDA==
 
-"@aws-cdk/asset-node-proxy-agent-v5@^2.0.21":
-  version "2.0.166"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/asset-node-proxy-agent-v5/-/asset-node-proxy-agent-v5-2.0.166.tgz#467507db141cd829ff8aa9d6ea5519310a4276b8"
-  integrity sha512-j0xnccpUQHXJKPgCwQcGGNu4lRiC1PptYfdxBIH1L4dRK91iBxtSQHESRQX+yB47oGLaF/WfNN/aF3WXwlhikg==
+"@aws-cdk/asset-node-proxy-agent-v6@^2.0.1":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/asset-node-proxy-agent-v6/-/asset-node-proxy-agent-v6-2.1.0.tgz#6d3c7860354d4856a7e75375f2f0ecab313b4989"
+  integrity sha512-7bY3J8GCVxLupn/kNmpPc5VJz8grx+4RKfnnJiO1LG+uxkZfANZG3RMHhE+qQxxwkyQ9/MfPtTpf748UhR425A==
 
 "@aws-cdk/cfnspec@2.68.0":
   version "2.68.0"
@@ -1248,22 +1248,23 @@ available-typed-arrays@^1.0.7:
   dependencies:
     possible-typed-array-names "^1.0.0"
 
-aws-cdk-lib@2.54.0:
-  version "2.54.0"
-  resolved "https://registry.yarnpkg.com/aws-cdk-lib/-/aws-cdk-lib-2.54.0.tgz#5271a4061a5be674e53815bf812d186be84855fe"
-  integrity sha512-DooUehpsNnFY2WjIxtXNBF37PTCvFSNK6E5c9cYpgQiofF3ayT7h7ppFhoWrc53trV3hw544kZDWL6aJszXCaA==
+aws-cdk-lib@2.109.0:
+  version "2.109.0"
+  resolved "https://registry.yarnpkg.com/aws-cdk-lib/-/aws-cdk-lib-2.109.0.tgz#60b2d115010cfd9bd541ee8586ae860c0367a5af"
+  integrity sha512-Va5j3eOrepm0H7a/VPvzCDRuPAL7z/xYMlrMJdFYHA3G1GmRvXnDgHWTiUYXh1AuBqJ4zUd4StRrBQhufAtHWw==
   dependencies:
-    "@aws-cdk/asset-awscli-v1" "^2.2.16"
-    "@aws-cdk/asset-kubectl-v20" "^2.1.1"
-    "@aws-cdk/asset-node-proxy-agent-v5" "^2.0.21"
+    "@aws-cdk/asset-awscli-v1" "^2.2.201"
+    "@aws-cdk/asset-kubectl-v20" "^2.1.2"
+    "@aws-cdk/asset-node-proxy-agent-v6" "^2.0.1"
     "@balena/dockerignore" "^1.0.2"
     case "1.6.3"
-    fs-extra "^9.1.0"
-    ignore "^5.2.0"
+    fs-extra "^11.1.1"
+    ignore "^5.2.4"
     jsonschema "^1.4.1"
     minimatch "^3.1.2"
-    punycode "^2.1.1"
-    semver "^7.3.8"
+    punycode "^2.3.1"
+    semver "^7.5.4"
+    table "^6.8.1"
     yaml "1.10.2"
 
 babel-jest@^27.5.1:
@@ -2564,6 +2565,15 @@ fs-extra@^10.1.0:
     jsonfile "^6.0.1"
     universalify "^2.0.0"
 
+fs-extra@^11.1.1:
+  version "11.3.1"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-11.3.1.tgz#ba7a1f97a85f94c6db2e52ff69570db3671d5a74"
+  integrity sha512-eXvGGwZ5CL17ZSwHWd3bbgk7UUpF6IFHtP57NYYakPvHOs8GDgDe5KJI36jIJzDkJ6eJjuzRA8eBQb6SkKue0g==
+  dependencies:
+    graceful-fs "^4.2.0"
+    jsonfile "^6.0.1"
+    universalify "^2.0.0"
+
 fs-extra@^8.1.0:
   version "8.1.0"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-8.1.0.tgz#49d43c45a88cd9677668cb7be1b46efdb8d2e1c0"
@@ -2940,7 +2950,7 @@ iconv-lite@0.6.3:
   dependencies:
     safer-buffer ">= 2.1.2 < 3.0.0"
 
-ignore@^5.2.0:
+ignore@^5.2.0, ignore@^5.2.4:
   version "5.3.2"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.3.2.tgz#3cd40e729f3643fd87cb04e50bf0eb722bc596f5"
   integrity sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==
@@ -4987,7 +4997,7 @@ semver-intersect@^1.5.0:
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.2.tgz#48d55db737c3287cd4835e17fa13feace1c41ef8"
   integrity sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==
 
-semver@7.x, semver@^7.0.0, semver@^7.3.2, semver@^7.3.4, semver@^7.3.8, semver@^7.5.3, semver@^7.6.0, semver@^7.7.1, semver@^7.7.2:
+semver@7.x, semver@^7.0.0, semver@^7.3.2, semver@^7.3.4, semver@^7.5.3, semver@^7.5.4, semver@^7.6.0, semver@^7.7.1, semver@^7.7.2:
   version "7.7.2"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.7.2.tgz#67d99fdcd35cec21e6f8b87a7fd515a33f982b58"
   integrity sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==


### PR DESCRIPTION
- #1527 

Updates `aws-cdk-lib` to minimum version supporting Python 3.12 lambda runtimes. Updates the `InitDefs` lambda runtime to `PYTHON_3_12` to remove usage of deprecated Python 3.9 runtime.

All other code changes are made from the pre-commit hooks.

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*